### PR TITLE
Fix pasteboard for iOS 9 or below

### DIFF
--- a/iOS/WAStickersThirdParty/Interoperability.swift
+++ b/iOS/WAStickersThirdParty/Interoperability.swift
@@ -36,7 +36,7 @@ struct Interoperability {
         if #available(iOS 10.0, *) {
             pasteboard.setItems([[PasteboardStickerPackDataType: dataToSend]], options: [UIPasteboardOption.localOnly: true, UIPasteboardOption.expirationDate: NSDate(timeIntervalSinceNow: PasteboardExpirationSeconds)])
         } else {
-            pasteboard.addItems([[PasteboardStickerPackDataType: dataToSend]])
+            pasteboard.setData(dataToSend, forPasteboardType: PasteboardStickerPackDataType)
         }
         DispatchQueue.main.async {
             if UIApplication.shared.canOpenURL(URL(string: "whatsapp://")!) {


### PR DESCRIPTION
As WhatsApp is using `-[UIPasteboard dataForPasteboardType:]` for reading data from pasteboard (in `-[WhatsAppAppDelegate processThirdPartyStickerPackWithBundleID:]`).

Before iOS 10, it should be using `-[UIPasteboard setData:forPasteboardType:]` instead of `-[UIPasteboard addItems:]` to avoid keep importing the same sticker pack or pop up **"There's a problem with this sticker pack and it can't be added to WhatsApp"** message.