### PR TITLE
Made compatible to allow running as "Universal" on iPad without crash

### DIFF
--- a/iOS/WAStickersThirdParty/AllStickerPacksViewController.swift
+++ b/iOS/WAStickersThirdParty/AllStickerPacksViewController.swift
@@ -99,6 +99,7 @@ class AllStickerPacksViewController: UIViewController, UITableViewDataSource, UI
 
         let addButton: UIButton = UIButton(type: .contactAdd)
         addButton.tag = indexPath.row
+        addButton.isEnabled = Interoperability.canSend()
         addButton.addTarget(self, action: #selector(addButtonTapped(button:)), for: .touchUpInside)
         cell.accessoryView = addButton
 

--- a/iOS/WAStickersThirdParty/AquaButton.swift
+++ b/iOS/WAStickersThirdParty/AquaButton.swift
@@ -38,6 +38,17 @@ class AquaButton: RoundedButton {
             imageView?.tintColor = newHighlighted ? UIColor.white.withAlphaComponent(0.5) : .white
         }
     }
+    
+    override var isEnabled: Bool {
+        didSet{
+            if self.isEnabled {
+                  imageView!.tintColor = .white
+            }
+            else{
+                  imageView!.tintColor = .lightGray
+            }
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -48,6 +59,7 @@ class AquaButton: RoundedButton {
 
         imageView!.tintColor = .white
         setTitleColor(UIColor.white.withAlphaComponent(0.5), for: .highlighted)
+        setTitleColor(UIColor.lightGray.withAlphaComponent(1.0), for: .disabled)
         imageEdgeInsets.left = -25
     }
     
@@ -70,7 +82,18 @@ class GrayRoundedButton: RoundedButton {
             imageView?.tintColor = newHighlighted ? aquaColor.withAlphaComponent(0.5) : aquaColor
         }
     }
-
+    
+    override var isEnabled: Bool {
+        didSet{
+            if self.isEnabled {
+                self.tintColor = UIColor.white
+            }
+            else{
+                self.tintColor = UIColor.gray
+            }
+        }
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
 

--- a/iOS/WAStickersThirdParty/Interoperability.swift
+++ b/iOS/WAStickersThirdParty/Interoperability.swift
@@ -17,6 +17,10 @@ struct Interoperability {
     static var iOSAppStoreLink: String?
     static var AndroidStoreLink: String?
 
+    static func canSend() -> Bool{
+        return UIApplication.shared.canOpenURL(URL(string: "whatsapp://")!)
+    }
+    
     static func send(json: [String: Any]) -> Bool {
         if let bundleIdentifier = Bundle.main.bundleIdentifier {
             if bundleIdentifier.contains(DefaultBundleIdentifier) {

--- a/iOS/WAStickersThirdParty/StickerPackViewController.swift
+++ b/iOS/WAStickersThirdParty/StickerPackViewController.swift
@@ -70,6 +70,7 @@ class StickerPackViewController: UIViewController, UICollectionViewDataSource, U
         addButton.setImage(buttonImage, for: .normal)
         addButton.addTarget(self, action: #selector(addButtonPressed(button:)), for: .touchUpInside)
         addButton.translatesAutoresizingMaskIntoConstraints = false
+        addButton.isEnabled = Interoperability.canSend()
         view.addSubview(addButton)
 
         let shareButton: GrayRoundedButton = GrayRoundedButton(frame: .zero)
@@ -218,12 +219,13 @@ class StickerPackViewController: UIViewController, UICollectionViewDataSource, U
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let sticker: Sticker = stickerPack.stickers[indexPath.item]
-        showActionSheet(withSticker: sticker)
+        let cell = collectionView.cellForItem(at: indexPath)
+        showActionSheet(withSticker: sticker, overCell: cell!)
     }
 
     // MARK: Targets
 
-    func showActionSheet(withSticker sticker: Sticker) {
+    func showActionSheet(withSticker sticker: Sticker, overCell cell: UICollectionViewCell) {
         var emojisString: String? = nil
         #if DEBUG
         if let emojis = sticker.emojis {
@@ -232,6 +234,11 @@ class StickerPackViewController: UIViewController, UICollectionViewDataSource, U
         #endif
 
         let actionSheet: UIAlertController = UIAlertController(title: "\n\n\n\n\n\n", message: emojisString, preferredStyle: .actionSheet)
+        
+        actionSheet.popoverPresentationController?.sourceView = cell.contentView
+        actionSheet.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection()
+        actionSheet.popoverPresentationController?.sourceRect = CGRect(x: cell.contentView.bounds.midX, y: cell.contentView.bounds.midY, width: 0, height: 0)
+
 
         actionSheet.addAction(UIAlertAction(title: "Copy to Clipboard", style: .default, handler: { action in
             sticker.copyToPasteboardAsImage()
@@ -253,6 +260,9 @@ class StickerPackViewController: UIViewController, UICollectionViewDataSource, U
         }
 
         let shareViewController: UIActivityViewController = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+        shareViewController.popoverPresentationController?.sourceView = self.view
+        shareViewController.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection()
+        shareViewController.popoverPresentationController?.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
         present(shareViewController, animated: true, completion: nil)
     }
 
@@ -287,6 +297,10 @@ class StickerPackViewController: UIViewController, UICollectionViewDataSource, U
         }
 
         let activityViewController: UIActivityViewController = UIActivityViewController(activityItems: stickerImages, applicationActivities: nil);
+        let parentView =  button as UIView
+        activityViewController.popoverPresentationController?.sourceView = parentView
+        activityViewController.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection()
+        activityViewController.popoverPresentationController?.sourceRect = CGRect(x: parentView.bounds.midX, y: parentView.bounds.midY, width: 0, height: 0)
         present(activityViewController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
Enabling iPad as run target will result in a crash as soon as a sticker is clicked. This is due to UIAlertController and UIActivityViewController needing a parent view to position themself on the screen. Adding this and a check for an installed WhatsApp to disable the "Add to Whatsapp" button in case it's not installed.