### PR TITLE
Added issue templates for Android and iOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/android.md
+++ b/.github/ISSUE_TEMPLATE/android.md
@@ -1,0 +1,20 @@
+---
+name: Android
+about: Choose this if you have an issue with the Android version.
+labels: 
+
+---
+
+<!---
+Please make sure that you label your issue with [Android] in the title.
+-->
+
+**Description of the problem**
+[Please describe your problem here]
+
+**Smartphone specs (if needed)**
+- OS Version:
+- Device:
+
+
+This is related to Android @simonzhexu

--- a/.github/ISSUE_TEMPLATE/ios.md
+++ b/.github/ISSUE_TEMPLATE/ios.md
@@ -1,0 +1,20 @@
+---
+name: iOS
+about: Choose this if you have an issue with the IOS version.
+labels: 
+
+---
+
+<!---
+Please make sure that you label your issue with [iOS] in the title.
+-->
+
+**Description of the problem**
+[Please describe your problem here]
+
+**Smartphone specs (if needed)**
+- OS Version:
+- Device:
+
+
+This is related to iOS @amrit-1901


### PR DESCRIPTION
Hey, 
I have added two issue templates for Android and iOS to make the issue page more understandable for unadvanced users. You can try them out in my fork at: https://github.com/MarvinJWendt/stickers/issues

When someone makes a new issue they will get asked if they want to make one for Android or iOS.
It should look like this:
![Issue templates](https://i.imgur.com/AWTBS44.png)

The templates automatically mention @simonzhexu (for android) or @amrit-1901 (for iOS) at the end of the issue, as this is suggested in the README.

The templates themself are kept simple:
- Description
- Smartphone specs

(I know @Zandor300 was first, I just made this to sepperate the Android issues from the iOS issues, as @Zandor300 packed both into one template)

__PS: CLA is signed :)__