### PR TITLE
Fix: Auto label for Android Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/android.md
+++ b/.github/ISSUE_TEMPLATE/android.md
@@ -1,10 +1,12 @@
 ---
 name: Android
 about: Template for issues about the android code/platform
-title: '[Android]'
-labels: android
+title: "[Android] "
+labels: Android
 assignees: simonzhexu
+
 ---
+
 <!-- 
 Only use the GitHub Issues section if you discovered issues with the code itself. Do not mistake the Issues page as a help desk. You can ask for help at [Stack Overflow](https://stackoverflow.com/). 
 -->

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,7 +1,12 @@
 ---
 name: General issue
 about: Template for general issues, which are not specific to Android or iOS
+title: ''
+labels: ''
+assignees: ''
+
 ---
+
 <!-- 
 Only use the GitHub Issues section if you discovered issues with the code itself. Do not mistake the Issues page as a help desk. You can ask for help at [Stack Overflow](https://stackoverflow.com/). 
 -->

--- a/.github/ISSUE_TEMPLATE/ios.md
+++ b/.github/ISSUE_TEMPLATE/ios.md
@@ -1,10 +1,12 @@
 ---
 name: iOS
 about: Template for issues about the iOS code/platform
-title: '[iOS]'
+title: "[iOS]"
 labels: iOS
 assignees: amrit-1901
+
 ---
+
 <!-- 
 Only use the GitHub Issues section if you discovered issues with the code itself. Do not mistake the Issues page as a help desk. You can ask for help at [Stack Overflow](https://stackoverflow.com/). 
 -->


### PR DESCRIPTION
We already have this for iOS but not for Android.
If someone uses the Android Issue template, it will automatically be labeled as `Android` now.