### PR TITLE
Fix: Autolabel for Android

### DIFF
--- a/.github/ISSUE_TEMPLATE/android.md
+++ b/.github/ISSUE_TEMPLATE/android.md
@@ -2,7 +2,7 @@
 name: Android
 about: Template for issues about the android code/platform
 title: '[Android]'
-labels: android
+labels: Android
 assignees: simonzhexu
 ---
 <!-- 


### PR DESCRIPTION
**Change description**  
The label name `Android` must be written with an uppercase `a` to be valid.
This adds support for automatically labeling Android Issues, when a user uses the Android Issue template.

**Prerequisites**
- [x] I have completed the CLA

@simonzhexu 