### PR TITLE
Add StackOverflow link to the issue templates (new GitHub feature)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Ask for help on StackOverflow
     url: https://stackoverflow.com/
-    about: Please ask and answer questions here.
+    about: Ask the awesome StackOverflow community for coding help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Ask for help on StackOverflow
-    url: https://stackoverflow.com/
+    url: https://stackoverflow.com/questions/tagged/whatsapp-stickers
     about: Ask the awesome StackOverflow community for coding help.


### PR DESCRIPTION
GitHub introduced a new feature to add links to the issue template chooser. This will add a link to StackOverflow to the issue template chooser:

![image](https://user-images.githubusercontent.com/31022056/68352415-a3566080-0106-11ea-874d-079e8b013b90.png)

This would probably help new users.