### PR TITLE
added support for animated stickers

### DIFF
--- a/Android/app/src/main/java/com/example/samplestickerapp/ContentFileParser.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/ContentFileParser.java
@@ -75,6 +75,7 @@ class ContentFileParser {
         String licenseAgreementWebsite = null;
         String imageDataVersion = "";
         boolean avoidCache = false;
+        boolean isAnimated = false;
         List<Sticker> stickerList = null;
         while (reader.hasNext()) {
             String key = reader.nextName();
@@ -112,6 +113,9 @@ class ContentFileParser {
                 case "avoid_cache":
                     avoidCache = reader.nextBoolean();
                     break;
+                case "isAnimated":
+                    isAnimated = reader.nextBoolean();
+                    break;
                 default:
                     reader.skipValue();
             }
@@ -138,7 +142,7 @@ class ContentFileParser {
             throw new IllegalStateException("image_data_version should not be empty");
         }
         reader.endObject();
-        final StickerPack stickerPack = new StickerPack(identifier, name, publisher, trayImageFile, publisherEmail, publisherWebsite, privacyPolicyWebsite, licenseAgreementWebsite, imageDataVersion, avoidCache);
+        final StickerPack stickerPack = new StickerPack(identifier, name, publisher, trayImageFile, publisherEmail, publisherWebsite, privacyPolicyWebsite, licenseAgreementWebsite, imageDataVersion, avoidCache, isAnimated);
         stickerPack.setStickers(stickerList);
         return stickerPack;
     }
@@ -152,6 +156,7 @@ class ContentFileParser {
             reader.beginObject();
             String imageFile = null;
             List<String> emojis = new ArrayList<>(StickerPackValidator.EMOJI_MAX_LIMIT);
+            boolean isAnimated = false;
             while (reader.hasNext()) {
                 final String key = reader.nextName();
                 if ("image_file".equals(key)) {
@@ -165,6 +170,8 @@ class ContentFileParser {
                         }
                     }
                     reader.endArray();
+                } else if ("isAnimated".equals(key)){
+                    isAnimated = reader.nextBoolean();
                 } else {
                     throw new IllegalStateException("unknown field in json: " + key);
                 }
@@ -179,7 +186,7 @@ class ContentFileParser {
             if (imageFile.contains("..") || imageFile.contains("/")) {
                 throw new IllegalStateException("the file name should not contain .. or / to prevent directory traversal, image file is:" + imageFile);
             }
-            stickerList.add(new Sticker(imageFile, emojis));
+            stickerList.add(new Sticker(imageFile, emojis,isAnimated));
         }
         reader.endArray();
         return stickerList;

--- a/Android/app/src/main/java/com/example/samplestickerapp/Sticker.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/Sticker.java
@@ -17,16 +17,19 @@ class Sticker implements Parcelable {
     final String imageFileName;
     final List<String> emojis;
     long size;
+    final boolean isAnimated;
 
-    Sticker(String imageFileName, List<String> emojis) {
+    Sticker(String imageFileName, List<String> emojis, boolean isAnimated) {
         this.imageFileName = imageFileName;
         this.emojis = emojis;
+        this.isAnimated = isAnimated;
     }
 
     private Sticker(Parcel in) {
         imageFileName = in.readString();
         emojis = in.createStringArrayList();
         size = in.readLong();
+        isAnimated = in.readByte() != 0; 
     }
 
     public static final Creator<Sticker> CREATOR = new Creator<Sticker>() {
@@ -55,5 +58,6 @@ class Sticker implements Parcelable {
         dest.writeString(imageFileName);
         dest.writeStringList(emojis);
         dest.writeLong(size);
+        dest.writeByte((byte) (isAnimated ? 1 : 0));
     }
 }

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerContentProvider.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerContentProvider.java
@@ -48,6 +48,8 @@ public class StickerContentProvider extends ContentProvider {
     public static final String LICENSE_AGREENMENT_WEBSITE = "sticker_pack_license_agreement_website";
     public static final String IMAGE_DATA_VERSION = "image_data_version";
     public static final String AVOID_CACHE = "whatsapp_will_not_cache_stickers";
+    public static final String ANIMATED_STICKER = "animated_sticker_pack";
+    public static final String STICKER_FILE_ANIMATED = "is_animated_sticker";
 
     public static final String STICKER_FILE_NAME_IN_QUERY = "sticker_file_name";
     public static final String STICKER_FILE_EMOJI_IN_QUERY = "sticker_emoji";
@@ -191,7 +193,9 @@ public class StickerContentProvider extends ContentProvider {
                         LICENSE_AGREENMENT_WEBSITE,
                         IMAGE_DATA_VERSION,
                         AVOID_CACHE,
+                        STICKER_FILE_ANIMATED,
                 });
+
         for (StickerPack stickerPack : stickerPackList) {
             MatrixCursor.RowBuilder builder = cursor.newRow();
             builder.add(stickerPack.identifier);
@@ -206,6 +210,7 @@ public class StickerContentProvider extends ContentProvider {
             builder.add(stickerPack.licenseAgreementWebsite);
             builder.add(stickerPack.imageDataVersion);
             builder.add(stickerPack.avoidCache ? 1 : 0);
+            builder.add(stickerPack.isAnimated ? 1 : 0);
         }
         cursor.setNotificationUri(Objects.requireNonNull(getContext()).getContentResolver(), uri);
         return cursor;
@@ -214,11 +219,11 @@ public class StickerContentProvider extends ContentProvider {
     @NonNull
     private Cursor getStickersForAStickerPack(@NonNull Uri uri) {
         final String identifier = uri.getLastPathSegment();
-        MatrixCursor cursor = new MatrixCursor(new String[]{STICKER_FILE_NAME_IN_QUERY, STICKER_FILE_EMOJI_IN_QUERY});
+        MatrixCursor cursor = new MatrixCursor(new String[]{STICKER_FILE_NAME_IN_QUERY, STICKER_FILE_EMOJI_IN_QUERY, STICKER_FILE_ANIMATED});
         for (StickerPack stickerPack : getStickerPackList()) {
             if (identifier.equals(stickerPack.identifier)) {
                 for (Sticker sticker : stickerPack.getStickers()) {
-                    cursor.addRow(new Object[]{sticker.imageFileName, TextUtils.join(",", sticker.emojis)});
+                    cursor.addRow(new Object[]{sticker.imageFileName, TextUtils.join(",", sticker.emojis), sticker.isAnimated});
                 }
             }
         }

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPack.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPack.java
@@ -24,6 +24,7 @@ class StickerPack implements Parcelable {
     final String licenseAgreementWebsite;
     final String imageDataVersion;
     final boolean avoidCache;
+    final boolean isAnimated;
 
     String iosAppStoreLink;
     private List<Sticker> stickers;
@@ -31,7 +32,7 @@ class StickerPack implements Parcelable {
     String androidPlayStoreLink;
     private boolean isWhitelisted;
 
-    StickerPack(String identifier, String name, String publisher, String trayImageFile, String publisherEmail, String publisherWebsite, String privacyPolicyWebsite, String licenseAgreementWebsite, String imageDataVersion, boolean avoidCache) {
+    StickerPack(String identifier, String name, String publisher, String trayImageFile, String publisherEmail, String publisherWebsite, String privacyPolicyWebsite, String licenseAgreementWebsite, String imageDataVersion, boolean avoidCache, boolean isAnimated) {
         this.identifier = identifier;
         this.name = name;
         this.publisher = publisher;
@@ -42,6 +43,7 @@ class StickerPack implements Parcelable {
         this.licenseAgreementWebsite = licenseAgreementWebsite;
         this.imageDataVersion = imageDataVersion;
         this.avoidCache = avoidCache;
+        this.isAnimated = isAnimated;
     }
 
     void setIsWhitelisted(boolean isWhitelisted) {
@@ -68,6 +70,7 @@ class StickerPack implements Parcelable {
         isWhitelisted = in.readByte() != 0;
         imageDataVersion = in.readString();
         avoidCache = in.readByte() != 0;
+        isAnimated = in.readByte() != 0;
     }
 
     public static final Creator<StickerPack> CREATOR = new Creator<StickerPack>() {
@@ -128,5 +131,6 @@ class StickerPack implements Parcelable {
         dest.writeByte((byte) (isWhitelisted ? 1 : 0));
         dest.writeString(imageDataVersion);
         dest.writeByte((byte) (avoidCache ? 1 : 0));
+        dest.writeByte((byte) (isAnimated ? 1 : 0));
     }
 }

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPackLoader.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPackLoader.java
@@ -38,6 +38,7 @@ import static com.example.samplestickerapp.StickerContentProvider.STICKER_PACK_I
 import static com.example.samplestickerapp.StickerContentProvider.STICKER_PACK_NAME_IN_QUERY;
 import static com.example.samplestickerapp.StickerContentProvider.STICKER_PACK_PUBLISHER_IN_QUERY;
 import static com.example.samplestickerapp.StickerContentProvider.IMAGE_DATA_VERSION;
+import static com.example.samplestickerapp.StickerContentProvider.STICKER_FILE_ANIMATED;
 
 class StickerPackLoader {
 
@@ -106,7 +107,8 @@ class StickerPackLoader {
             final String licenseAgreementWebsite = cursor.getString(cursor.getColumnIndexOrThrow(LICENSE_AGREENMENT_WEBSITE));
             final String imageDataVersion = cursor.getString(cursor.getColumnIndexOrThrow(IMAGE_DATA_VERSION));
             final boolean avoidCache = cursor.getShort(cursor.getColumnIndexOrThrow(AVOID_CACHE)) > 0;
-            final StickerPack stickerPack = new StickerPack(identifier, name, publisher, trayImage, publisherEmail, publisherWebsite, privacyPolicyWebsite, licenseAgreementWebsite, imageDataVersion, avoidCache);
+            final boolean isAnimated = cursor.getShort(cursor.getColumnIndexOrThrow(STICKER_FILE_ANIMATED)) > 0;
+            final StickerPack stickerPack = new StickerPack(identifier, name, publisher, trayImage, publisherEmail, publisherWebsite, privacyPolicyWebsite, licenseAgreementWebsite, imageDataVersion, avoidCache, isAnimated);
             stickerPack.setAndroidPlayStoreLink(androidPlayStoreLink);
             stickerPack.setIosAppStoreLink(iosAppLink);
             stickerPackList.add(stickerPack);
@@ -118,7 +120,7 @@ class StickerPackLoader {
     private static List<Sticker> fetchFromContentProviderForStickers(String identifier, ContentResolver contentResolver) {
         Uri uri = getStickerListUri(identifier);
 
-        final String[] projection = {STICKER_FILE_NAME_IN_QUERY, STICKER_FILE_EMOJI_IN_QUERY};
+        final String[] projection = {STICKER_FILE_NAME_IN_QUERY, STICKER_FILE_EMOJI_IN_QUERY,STICKER_FILE_ANIMATED};
         final Cursor cursor = contentResolver.query(uri, projection, null, null, null);
         List<Sticker> stickers = new ArrayList<>();
         if (cursor != null && cursor.getCount() > 0) {
@@ -130,7 +132,8 @@ class StickerPackLoader {
                 if (!TextUtils.isEmpty(emojisConcatenated)) {
                     emojis = Arrays.asList(emojisConcatenated.split(","));
                 }
-                stickers.add(new Sticker(name, emojis));
+                boolean isAnimated = cursor.getColumnIndexOrThrow(STICKER_FILE_ANIMATED) > 0;
+                stickers.add(new Sticker(name, emojis, isAnimated));
             } while (cursor.moveToNext());
         }
         if (cursor != null) {


### PR DESCRIPTION
Added support for android ONLY
You need to have root access and change the `/data/data/com.whatsapp/shared_prefs/com.whatsapp_prefrences.xml` file on your phone to support third party animated stickers by adding `<boolean name="third_party_animated_sticker" value="true"/>` between the map brackets.