### PR TITLE
[Android] fix some typos in StickerContentProvider comments and varia…

### DIFF
--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerContentProvider.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerContentProvider.java
@@ -45,7 +45,7 @@ public class StickerContentProvider extends ContentProvider {
     public static final String PUBLISHER_EMAIL = "sticker_pack_publisher_email";
     public static final String PUBLISHER_WEBSITE = "sticker_pack_publisher_website";
     public static final String PRIVACY_POLICY_WEBSITE = "sticker_pack_privacy_policy_website";
-    public static final String LICENSE_AGREENMENT_WEBSITE = "sticker_pack_license_agreement_website";
+    public static final String LICENSE_AGREEMENT_WEBSITE = "sticker_pack_license_agreement_website";
     public static final String IMAGE_DATA_VERSION = "image_data_version";
     public static final String AVOID_CACHE = "whatsapp_will_not_cache_stickers";
     public static final String ANIMATED_STICKER_PACK = "animated_sticker_pack";
@@ -88,7 +88,7 @@ public class StickerContentProvider extends ContentProvider {
         //the call to get the metadata for single sticker pack. * represent the identifier
         MATCHER.addURI(authority, METADATA + "/*", METADATA_CODE_FOR_SINGLE_PACK);
 
-        //gets the list of stickers for a sticker pack, * respresent the identifier.
+        //gets the list of stickers for a sticker pack, * represent the identifier.
         MATCHER.addURI(authority, STICKERS + "/*", STICKERS_CODE);
 
         for (StickerPack stickerPack : getStickerPackList()) {
@@ -189,7 +189,7 @@ public class StickerContentProvider extends ContentProvider {
                         PUBLISHER_EMAIL,
                         PUBLISHER_WEBSITE,
                         PRIVACY_POLICY_WEBSITE,
-                        LICENSE_AGREENMENT_WEBSITE,
+                        LICENSE_AGREEMENT_WEBSITE,
                         IMAGE_DATA_VERSION,
                         AVOID_CACHE,
                         ANIMATED_STICKER_PACK,

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPackLoader.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPackLoader.java
@@ -29,7 +29,7 @@ import static com.example.samplestickerapp.StickerContentProvider.ANIMATED_STICK
 import static com.example.samplestickerapp.StickerContentProvider.AVOID_CACHE;
 import static com.example.samplestickerapp.StickerContentProvider.IMAGE_DATA_VERSION;
 import static com.example.samplestickerapp.StickerContentProvider.IOS_APP_DOWNLOAD_LINK_IN_QUERY;
-import static com.example.samplestickerapp.StickerContentProvider.LICENSE_AGREENMENT_WEBSITE;
+import static com.example.samplestickerapp.StickerContentProvider.LICENSE_AGREEMENT_WEBSITE;
 import static com.example.samplestickerapp.StickerContentProvider.PRIVACY_POLICY_WEBSITE;
 import static com.example.samplestickerapp.StickerContentProvider.PUBLISHER_EMAIL;
 import static com.example.samplestickerapp.StickerContentProvider.PUBLISHER_WEBSITE;
@@ -104,7 +104,7 @@ class StickerPackLoader {
             final String publisherEmail = cursor.getString(cursor.getColumnIndexOrThrow(PUBLISHER_EMAIL));
             final String publisherWebsite = cursor.getString(cursor.getColumnIndexOrThrow(PUBLISHER_WEBSITE));
             final String privacyPolicyWebsite = cursor.getString(cursor.getColumnIndexOrThrow(PRIVACY_POLICY_WEBSITE));
-            final String licenseAgreementWebsite = cursor.getString(cursor.getColumnIndexOrThrow(LICENSE_AGREENMENT_WEBSITE));
+            final String licenseAgreementWebsite = cursor.getString(cursor.getColumnIndexOrThrow(LICENSE_AGREEMENT_WEBSITE));
             final String imageDataVersion = cursor.getString(cursor.getColumnIndexOrThrow(IMAGE_DATA_VERSION));
             final boolean avoidCache = cursor.getShort(cursor.getColumnIndexOrThrow(AVOID_CACHE)) > 0;
             final boolean animatedStickerPack = cursor.getShort(cursor.getColumnIndexOrThrow(ANIMATED_STICKER_PACK)) > 0;


### PR DESCRIPTION
I found some typos in the StickerContentProvider.java file and fixed them.

One is on the static global variable `LICENSE_AGREENMENT_WEBSITE` (the word `AGREENMENT` -> `AGREEMENT`)
And the other in the comment in line 91 (`respresent` -> `represent`)
```
//gets the list of stickers for a sticker pack, respresent the identifier. 
MATCHER.addURI(authority, STICKERS + "/*", STICKERS_CODE);
``` 
