### PR TITLE
Add copyright headers to all source files

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 apply plugin: 'com.android.application'
 
 android {

--- a/Android/app/proguard-rules.pro
+++ b/Android/app/proguard-rules.pro
@@ -1,3 +1,11 @@
+#
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
 # Add project specific ProGuard rules here.
 # You can control the set of applied configuration files using the
 # proguardFiles setting in build.gradle.

--- a/Android/app/src/main/java/com/example/samplestickerapp/AddStickerPackActivity.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/AddStickerPackActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/BaseActivity.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/BaseActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/BottomFadingRecyclerView.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/BottomFadingRecyclerView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/ContentFileParser.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/ContentFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/EntryActivity.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/EntryActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/Sticker.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/Sticker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerApplication.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerContentProvider.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerContentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPack.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPackDetailsActivity.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPackDetailsActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPackInfoActivity.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPackInfoActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPackListActivity.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPackListActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPackListAdapter.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPackListAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPackListItemViewHolder.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPackListItemViewHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPackLoader.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPackLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPackValidator.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPackValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPreviewAdapter.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPreviewAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/StickerPreviewViewHolder.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/StickerPreviewViewHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/app/src/main/java/com/example/samplestickerapp/WhitelistCheck.java
+++ b/Android/app/src/main/java/com/example/samplestickerapp/WhitelistCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WhatsApp Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {

--- a/Android/gradle.properties
+++ b/Android/gradle.properties
@@ -1,3 +1,11 @@
+#
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
 # Project-wide Gradle settings.
 
 # IDE (e.g. Android Studio) users:

--- a/Android/settings.gradle
+++ b/Android/settings.gradle
@@ -1,1 +1,9 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 include ':app'

--- a/iOS/WAStickersThirdParty/AllStickerPacksViewController.swift
+++ b/iOS/WAStickersThirdParty/AllStickerPacksViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/AppDelegate.swift
+++ b/iOS/WAStickersThirdParty/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/AquaButton.swift
+++ b/iOS/WAStickersThirdParty/AquaButton.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -38,7 +38,7 @@ class AquaButton: RoundedButton {
             imageView?.tintColor = newHighlighted ? UIColor.white.withAlphaComponent(0.5) : .white
         }
     }
-    
+
     override var isEnabled: Bool {
         didSet{
             if isEnabled {
@@ -61,7 +61,7 @@ class AquaButton: RoundedButton {
         setTitleColor(UIColor.lightGray.withAlphaComponent(1.0), for: .disabled)
         imageEdgeInsets.left = -25
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -81,7 +81,7 @@ class GrayRoundedButton: RoundedButton {
             imageView?.tintColor = newHighlighted ? aquaColor.withAlphaComponent(0.5) : aquaColor
         }
     }
-    
+
     override var isEnabled: Bool {
         didSet{
             if isEnabled {
@@ -91,7 +91,7 @@ class GrayRoundedButton: RoundedButton {
             }
         }
     }
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 

--- a/iOS/WAStickersThirdParty/GradientView.swift
+++ b/iOS/WAStickersThirdParty/GradientView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/ImageData.swift
+++ b/iOS/WAStickersThirdParty/ImageData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/Interoperability.swift
+++ b/iOS/WAStickersThirdParty/Interoperability.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -20,7 +20,7 @@ struct Interoperability {
     static func canSend() -> Bool {
         return UIApplication.shared.canOpenURL(URL(string: "whatsapp://")!)
     }
-    
+
     static func send(json: [String: Any]) -> Bool {
         if Bundle.main.bundleIdentifier?.contains(DefaultBundleIdentifier) == true {
           fatalError("Your bundle identifier must not include the default one.")

--- a/iOS/WAStickersThirdParty/Limits.swift
+++ b/iOS/WAStickersThirdParty/Limits.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -25,7 +25,7 @@ struct Limits {
     static let MaxCharLimit128: Int = 128
 
     static let MaxEmojisCount: Int = 3
-    
+
     static let MaxStaticStickerAccessibilityTextCharLimit = 125
     static let MaxAnimatedStickerAccessibilityTextCharLimit = 255
 }

--- a/iOS/WAStickersThirdParty/LinkTableViewCell.swift
+++ b/iOS/WAStickersThirdParty/LinkTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/SecondaryTextTableViewCell.swift
+++ b/iOS/WAStickersThirdParty/SecondaryTextTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/Sticker.swift
+++ b/iOS/WAStickersThirdParty/Sticker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -69,7 +69,7 @@ struct StickerAccessibilityText {
         animated: Bool
     ) throws -> String? {
         guard let accessibilityText else { return nil }
-        
+
         if animated {
             guard accessibilityText.count <= Limits.MaxAnimatedStickerAccessibilityTextCharLimit else {
                 throw StickerPackError.animatedStickerAccessibilityTextTooLong
@@ -79,7 +79,7 @@ struct StickerAccessibilityText {
                 throw StickerPackError.staticStickerAccessibilityTextTooLong
             }
         }
-        
+
         return accessibilityText
     }
 }

--- a/iOS/WAStickersThirdParty/StickerCell.swift
+++ b/iOS/WAStickersThirdParty/StickerCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/StickerPack.swift
+++ b/iOS/WAStickersThirdParty/StickerPack.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/StickerPackInfoViewController.swift
+++ b/iOS/WAStickersThirdParty/StickerPackInfoViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -61,7 +61,7 @@ class StickerPackInfoViewController: UITableViewController {
         tableView.register(UINib(nibName: "SecondaryTextTableViewCell", bundle: nil), forCellReuseIdentifier: "SecondaryCell")
         tableView.register(UINib(nibName: "LinkTableViewCell", bundle: nil), forCellReuseIdentifier: "LinkCell")
     }
-    
+
     @IBAction func donePressed(_ sender: UIBarButtonItem) {
         dismiss(animated: true)
     }
@@ -88,9 +88,9 @@ class StickerPackInfoViewController: UITableViewController {
             label.setContentCompressionResistancePriority(.required, for: .horizontal)
             label.setContentCompressionResistancePriority(.required, for: .vertical)
             addSubview(label)
-            
+
             // Add constraints
-            
+
             addConstraint(NSLayoutConstraint(item: label, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: FooterView.MARGIN))
             addConstraint(NSLayoutConstraint(item: label, attribute: .leading, relatedBy: .equal, toItem: self, attribute: .leadingMargin, multiplier: 1.0, constant: FooterView.MARGIN))
             addConstraint(NSLayoutConstraint(item: label, attribute: .trailing, relatedBy: .equal, toItem: self, attribute: .trailingMargin, multiplier: 1.0, constant: -FooterView.MARGIN))

--- a/iOS/WAStickersThirdParty/StickerPackManager.swift
+++ b/iOS/WAStickersThirdParty/StickerPackManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/StickerPackTableViewCell.swift
+++ b/iOS/WAStickersThirdParty/StickerPackTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/StickerPackViewController.swift
+++ b/iOS/WAStickersThirdParty/StickerPackViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -232,7 +232,7 @@ class StickerPackViewController: UIViewController, UICollectionViewDataSource, U
         if let emojis = sticker.emojis {
             message = emojis.joined(separator: " ")
         }
-        
+
         if let accessibilityText = sticker.accessibilityText {
             if let currentMessage = message {
                 message = currentMessage + "\n" + accessibilityText
@@ -243,7 +243,7 @@ class StickerPackViewController: UIViewController, UICollectionViewDataSource, U
         #endif
 
         let actionSheet: UIAlertController = UIAlertController(title: "\n\n\n\n\n\n\n", message: message, preferredStyle: .actionSheet)
-        
+
         actionSheet.popoverPresentationController?.sourceView = cell.contentView
         actionSheet.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection()
         actionSheet.popoverPresentationController?.sourceRect = CGRect(x: cell.contentView.bounds.midX, y: cell.contentView.bounds.midY, width: 0, height: 0)

--- a/iOS/WAStickersThirdParty/UIAlertController+Additions.swift
+++ b/iOS/WAStickersThirdParty/UIAlertController+Additions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/WAStickersThirdParty-Bridging-Header.h
+++ b/iOS/WAStickersThirdParty/WAStickersThirdParty-Bridging-Header.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the

--- a/iOS/WAStickersThirdParty/WebPManager.swift
+++ b/iOS/WAStickersThirdParty/WebPManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) WhatsApp Inc. and its affiliates.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
This PR adds Meta copyright headers to all source files in the repository that were missing them, ensuring compliance with open source licensing requirements.